### PR TITLE
Update 201023

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -48,6 +48,7 @@ RUN git clone https://github.com/zsh-users/zsh-autosuggestions /home/${USER}/.oh
 RUN git clone https://github.com/tfutils/tfenv.git /usr/local/tfenv && \
   ln -s /usr/local/tfenv/bin/* /usr/local/bin/ && \
   tfenv install 1.2.6 && \
+  tfenv install 1.6.1 && \
   tfenv use 1.2.6
 
 # Set the default shell to ZSH and source .zshrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,9 @@
         "dockerfile": "Dockerfile"
     },
     "mounts": [
-        "source=${localEnv:HOME}/.aws,target=/home/vscode/.aws,type=bind,consistency=cached"
+        "source=${localEnv:HOME}/.aws,target=/home/vscode/.aws,type=bind,consistency=cached",
+        "source=${localEnv:HOME}/.zshrc,target=/home/vscode/.zshrc,type=bind,consistency=cached",
+        "source=${localEnv:HOME}/.oh-my-zsh/custom,target=/home/vscode/.oh-my-zsh/custom,type=bind,consistency=cached"
     ],
     "customizations": {
         "vscode": {


### PR DESCRIPTION
- [include latest TF ver, and install arm awscli](https://github.com/BurendoUK/burendo-devcontainer/commit/9892e8fc37844b08ad68ce15de6d0215341b9346)
- [mount your own zsh aliases and zshrc](https://github.com/BurendoUK/burendo-devcontainer/commit/e5f6c1d0a97b752479e6ebead834c0a1893952d0)